### PR TITLE
外部ライブラリを GAS で用いる例

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,6 +1,12 @@
 {
   "timeZone": "Asia/Tokyo",
-  "dependencies": {},
+  "dependencies": {
+    "libraries": [{
+      "userSymbol": "LodashGS",
+      "libraryId": "1SQ0PlSMwndIuOAgtVJdjxsuXueECtY9OGejVDS37ckSVbMll73EXf2PW",
+      "version": "5"
+    }]
+  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8"
 }

--- a/code.js
+++ b/code.js
@@ -10,6 +10,7 @@
 
 const ADDON_NAME = PropertiesService.getScriptProperties().getProperty("ADDON_NAME");
 
+const _ = LodashGS.load();
 /**
  * Creates a menu entry in the Google Docs UI when the document is opened.
  *
@@ -130,7 +131,7 @@ function nannenkanji(grade) {
     }
   }
 
-  return bookmarks;
+  return _.reverse(bookmarks);
 }
 
 /**


### PR DESCRIPTION
　外部ライブラリを GAS で用いる例として、(ここではあまり必要はありませんが) Lodash をインポートして配列操作をしてみました。リソースからライブラリを選択して、ライブラリの id を打ち込むと利用できるようです。ライブラリを GAS Editor で import 後は、clasp pull とすると、appsscript.json が更新されます。
　また、この Pull Request を merge すると、issue が自動で閉じるように "Closes #イシューの番号" と書いています。

Closes #4 